### PR TITLE
Reconfigure results grid and card borders

### DIFF
--- a/src/components/CarrierFinderApp.tsx
+++ b/src/components/CarrierFinderApp.tsx
@@ -144,7 +144,7 @@ export default function CarrierFinderApp() {
             <div className="skeleton h-10 rounded-xl"></div>
             <div className="skeleton h-10 rounded-xl"></div>
           </div>
-          <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div className="skeleton h-24 rounded-2xl"></div>
             <div className="skeleton h-24 rounded-2xl"></div>
             <div className="skeleton h-24 rounded-2xl"></div>
@@ -206,7 +206,7 @@ export default function CarrierFinderApp() {
           )}
 
           <div className="grid grid-cols-1 lg:grid-cols-4 gap-4 min-w-0">
-            <div className="lg:col-span-3 grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4 min-w-0">
+            <div className="lg:col-span-3 grid grid-cols-1 md:grid-cols-2 gap-4 min-w-0">
               <ResultColumn title="Точные" emptyText="Нет точных совпадений">
                 {results.exact.map((r) => (
                   <ResultCard
@@ -226,7 +226,7 @@ export default function CarrierFinderApp() {
                 ))}
               </ResultColumn>
               {showComposite && results.composite && (
-                <div className="md:col-span-2 xl:col-span-3 min-w-0">
+                <div className="md:col-span-2 min-w-0">
                   <CompositePanel
                   variants={(results.compositeAlts && results.compositeAlts.length
                     ? [results.composite!, ...results.compositeAlts.filter(v => v.path.join('>') !== results.composite!.path.join('>'))]

--- a/src/index.css
+++ b/src/index.css
@@ -50,7 +50,7 @@ small, .caption { @apply text-sm leading-6 text-neutral-600 dark:text-neutral-30
   .input { @apply w-full rounded-xl px-3 py-2 bg-white/70 dark:bg-white/5 backdrop-blur border border-white/40 dark:border-white/10 shadow-soft-inset placeholder:text-neutral-400 focus:outline-none focus:ring-2 focus:ring-primary-500; }
 
   /* Cards */
-  .card { @apply rounded-2xl bg-white/70 dark:bg-white/5 backdrop-blur shadow-elev-1 border border-white/40 dark:border-white/10; }
+  .card { @apply rounded-2xl bg-white/70 dark:bg-white/5 backdrop-blur shadow-elev-1 border border-neutral-200 dark:border-white/10; }
   li.card { width: 100%; }
   .card .text-lg.font-semibold { white-space: nowrap; overflow-x: auto; }
   .glass { @apply bg-glass backdrop-blur; }


### PR DESCRIPTION
## Summary
- Simplify carrier search results layout to a two-column grid and move the composite panel to its own row
- Switch card outlines to a neutral border for clearer separation

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c70e98fff4832189e0fb63a6ae141a