### PR TITLE
feat: add generic ratings table component

### DIFF
--- a/src/components/RatingsTable.tsx
+++ b/src/components/RatingsTable.tsx
@@ -1,0 +1,116 @@
+import React, { useMemo, useState } from 'react'
+
+export interface Column<T> {
+  key: keyof T
+  label: string
+  render?: (row: T) => React.ReactNode
+}
+
+interface RatingsTableProps<T> {
+  data: T[]
+  columns: Column<T>[]
+  pageSize?: number
+  className?: string
+}
+
+function RatingsTable<T extends Record<string, any>>({
+  data,
+  columns,
+  pageSize = 50,
+  className = '',
+}: RatingsTableProps<T>) {
+  const [sortKey, setSortKey] = useState<keyof T | null>(null)
+  const [sortDir, setSortDir] = useState<'asc' | 'desc'>('asc')
+  const [page, setPage] = useState(0)
+
+  function handleSort(key: keyof T) {
+    if (sortKey === key) {
+      setSortDir(sortDir === 'asc' ? 'desc' : 'asc')
+    } else {
+      setSortKey(key)
+      setSortDir('asc')
+    }
+    setPage(0)
+  }
+
+  const sorted = useMemo(() => {
+    if (!sortKey) return data
+    return [...data].sort((a, b) => {
+      const av = a[sortKey]
+      const bv = b[sortKey]
+      if (av == null && bv == null) return 0
+      if (av == null) return 1
+      if (bv == null) return -1
+      if (typeof av === 'number' && typeof bv === 'number') {
+        return sortDir === 'asc' ? av - bv : bv - av
+      }
+      return sortDir === 'asc'
+        ? String(av).localeCompare(String(bv))
+        : String(bv).localeCompare(String(av))
+    })
+  }, [data, sortKey, sortDir])
+
+  const totalPages = Math.ceil(sorted.length / pageSize)
+  const paged = useMemo(() => {
+    const start = page * pageSize
+    return sorted.slice(start, start + pageSize)
+  }, [sorted, page, pageSize])
+
+  return (
+    <div className={`overflow-auto ${className}`}>
+      <table className="min-w-full text-sm">
+        <thead>
+          <tr>
+            {columns.map((col) => (
+              <th
+                key={String(col.key)}
+                onClick={() => handleSort(col.key)}
+                className="px-2 py-1 text-left cursor-pointer select-none"
+              >
+                {col.label}
+                {sortKey === col.key && (
+                  <span className="ml-1">{sortDir === 'asc' ? '▲' : '▼'}</span>
+                )}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {paged.map((row, i) => (
+            <tr key={i} className="odd:bg-gray-50">
+              {columns.map((col) => (
+                <td key={String(col.key)} className="px-2 py-1">
+                  {col.render ? col.render(row) : (row[col.key] as any)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between mt-2 text-sm">
+          <button
+            className="px-2 py-1 border rounded disabled:opacity-50"
+            onClick={() => setPage((p) => Math.max(0, p - 1))}
+            disabled={page === 0}
+          >
+            Пред.
+          </button>
+          <div>
+            {page + 1} / {totalPages}
+          </div>
+          <button
+            className="px-2 py-1 border rounded disabled:opacity-50"
+            onClick={() => setPage((p) => Math.min(totalPages - 1, p + 1))}
+            disabled={page >= totalPages - 1}
+          >
+            След.
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default RatingsTable
+


### PR DESCRIPTION
## Summary
- add reusable RatingsTable component with sortable columns and basic pagination

## Testing
- `npm test` (fails: Missing script)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c813f6d14c83219b05bc70c09e26d2