### PR TITLE
refactor: update city rating fields

### DIFF
--- a/src/components/RatingsPage.tsx
+++ b/src/components/RatingsPage.tsx
@@ -197,7 +197,7 @@ function renderCityTable(rows: CityRating[]) {
             <th className="px-2 py-1 text-left">Сделок завершилось</th>
             <th className="px-2 py-1 text-left">Сумма ставок (старт)</th>
             <th className="px-2 py-1 text-left">Сумма ставок (финиш)</th>
-            <th className="px-2 py-1 text-left">Общий объём (ставка)</th>
+            <th className="px-2 py-1 text-left">Сумма ставок (итого)</th>
             <th className="px-2 py-1 text-left">Маршрутов через город</th>
             <th className="px-2 py-1 text-left">Плотность парка</th>
             <th className="px-2 py-1 text-left">Средняя ставка</th>
@@ -210,12 +210,12 @@ function renderCityTable(rows: CityRating[]) {
               <td className="px-2 py-1">{r.rating}</td>
               <td className="px-2 py-1">{r.dealsStarted}</td>
               <td className="px-2 py-1">{r.dealsFinished}</td>
-              <td className="px-2 py-1">{r.sumStart}</td>
-              <td className="px-2 py-1">{r.sumFinish}</td>
-              <td className="px-2 py-1">{r.totalBid}</td>
-              <td className="px-2 py-1">{r.routesThroughCity}</td>
+              <td className="px-2 py-1">{r.bidsStart}</td>
+              <td className="px-2 py-1">{r.bidsFinish}</td>
+              <td className="px-2 py-1">{r.bidsTotal}</td>
+              <td className="px-2 py-1">{r.routes}</td>
               <td className="px-2 py-1">{r.fleetDensity}</td>
-              <td className="px-2 py-1">{r.averageBid}</td>
+              <td className="px-2 py-1">{r.avgBid}</td>
             </tr>
           ))}
         </tbody>

--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -91,16 +91,22 @@ export async function loadLinePaths(): Promise<string[][]> {
 export async function loadCityRatings(): Promise<CityRating[]> {
   const rows = stripBomRows(await fetchCsv('/data/city_ratings.csv'))
   return rows.map((r) => ({
-    dealsStarted: Number(r['Сделок началось'] || '0'),
-    dealsFinished: Number(r['Сделок завершилось'] || '0'),
-    city: r['Город'] || '',
-    sumStart: Number(r['Сумма ставок (старт)'] || '0'),
-    sumFinish: Number(r['Сумма ставок (финиш)'] || '0'),
-    totalBid: Number(r['Общий объём (ставка)'] || '0'),
-    routesThroughCity: Number(r['Маршрутов через город'] || '0'),
-    fleetDensity: Number(r['Плотность водительского парка'] || '0'),
-    averageBid: Number(r['Средняя ставка (по сделкам города)'] || '0'),
-    rating: Number(r['Рейтинг'] || '0'),
+    city: r['City'] || r['Город'] || '',
+    rating: Number(r['Rating'] || r['Рейтинг'] || '0'),
+    dealsStarted: Number(r['Deals started'] || r['Сделок началось'] || '0'),
+    dealsFinished: Number(r['Deals finished'] || r['Сделок завершилось'] || '0'),
+    bidsStart: Number(r['Bids sum (start)'] || r['Сумма ставок (старт)'] || '0'),
+    bidsFinish: Number(r['Bids sum (finish)'] || r['Сумма ставок (финиш)'] || '0'),
+    bidsTotal: Number(r['Total bid volume'] || r['Общий объём (ставка)'] || '0'),
+    routes: Number(r['Routes through city'] || r['Маршрутов через город'] || '0'),
+    fleetDensity: Number(r['Fleet density'] || r['Плотность водительского парка'] || '0'),
+    avgBid:
+      Number(
+        r['Average bid (city deals)'] ||
+          r['Average bid'] ||
+          r['Средняя ставка (по сделкам города)'] ||
+          '0'
+      ),
   }))
 }
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,16 +59,16 @@ export type SearchResults = {
 }
 
 export interface CityRating {
+  city: string
+  rating: number
   dealsStarted: number
   dealsFinished: number
-  city: string
-  sumStart: number
-  sumFinish: number
-  totalBid: number
-  routesThroughCity: number
+  bidsStart: number
+  bidsFinish: number
+  bidsTotal: number
+  routes: number
   fleetDensity: number
-  averageBid: number
-  rating: number
+  avgBid: number
 }
 
 export interface RouteRating {


### PR DESCRIPTION
## Summary
- align city rating interface with new dataset structure
- adjust CSV parsing for renamed city rating columns
- update city ratings table to use new field names

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c818e6bbd48321aea313f21bcf1345