### PR TITLE
feat: extend carrier ratings filters

### DIFF
--- a/src/lib/csv.ts
+++ b/src/lib/csv.ts
@@ -139,10 +139,19 @@ export async function loadRouteRatings(): Promise<RouteRating[]> {
 export async function loadDriverRatings(): Promise<DriverRating[]> {
   const rows = stripBomRows(await fetchCsv('/data/driver_ratings.csv'))
   return rows.map((r) => ({
-    name: r['ФИО'] || '',
-    phone: r['ТЕЛЕФОН'] || '',
-    deals: Number(r['Количество сделок'] || '0'),
-    bidsSum: Number(r['Общая сумма'] || '0'),
-    routes: Number(r['Доступные маршруты'] || '0'),
+    name: r['ФИО'] || r['Name'] || '',
+    phone: r['ТЕЛЕФОН'] || r['Phone'] || '',
+    segments: Number(r['Segments'] || r['Сегментов'] || '0'),
+    deals: Number(r['Количество сделок'] || r['Deals'] || '0'),
+    bidsSum: Number(r['Общая сумма'] || r['Bids sum'] || '0'),
+    avgBid: Number(r['Средняя ставка'] || r['Average bid'] || '0'),
+    uniqueRoutes: Number(
+      r['Доступные маршруты'] ||
+        r['Routes'] ||
+        r['Уникальных маршрутов'] ||
+        '0'
+    ),
+    uniqueCities: Number(r['Уникальных городов'] || r['Unique cities'] || '0'),
+    topRoute: r['Топ маршрут'] || r['Top route'] || '',
   }))
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -83,7 +83,11 @@ export interface RouteRating {
 export interface DriverRating {
   name: string
   phone: string
+  segments: number
   deals: number
   bidsSum: number
-  routes: number
+  avgBid: number
+  uniqueRoutes: number
+  uniqueCities: number
+  topRoute: string
 }


### PR DESCRIPTION
## Summary
- expand DriverRating and CSV loader with segments, avgBid, uniqueRoutes, uniqueCities and topRoute fields
- extend RatingsPage with corresponding carrier filters and reuse generic RatingsTable to render all rating types

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68c81e1a92d08321a0920c93af144a03