### PR TITLE
Load deals data and display driver cost info in composite panel

### DIFF
--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -11,6 +11,16 @@ export type Driver = {
   corridors: string[]
 }
 
+export type RouteKey = string
+
+export type Deal = {
+  phone: string
+  driverId?: number
+  from: string
+  to: string
+  cost: number
+}
+
 export type Indices = {
   pairExact: Map<string, Set<number>>
   subpathDir: Map<string, Set<number>>


### PR DESCRIPTION
## Summary
- load deals and route data during app initialization to populate cost maps used for pricing estimates
- pass aggregated driver cost callback into the composite panel so segment chips show average prices per carrier
- define shared Deal and RouteKey types for CSV parsing helpers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c8649c0f24832193ceaf3f752cb736